### PR TITLE
SF-5622: taskforce update taskforce ci to deploy service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,55 +24,17 @@ jobs:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: "Run build"
-          command: |
-            npm run build
-  code-checks:
-    docker:
-      - image: cimg/node:20.9.0
-    steps:
-        - checkout
-        - run:
-            name: "Install yarn"
-            command: sudo npm install -g yarn
-        - restore_cache:
-            name: "Restore Package Cache"
-            keys:
-                - yarn-packages-{{ checksum "yarn.lock" }}
-        - run:
-            name: "Install dependencies"
-            command: yarn --frozen-lockfile
-        - save_cache:
-            name: "Save Package Cache"
-            key: yarn-packages-{{ checksum "yarn.lock" }}
-            paths:
-                - node_modules
-# no lint and type checks in this project
-#        - run:
-#            name: "Run lint checks"
-#            command: pnpm lint-check
-#        - run:
-#            name: "Run type checks"
-#            command: pnpm type-check
-#        - run:
-#            name: "Run tests"
-#            command: pnpm test
+          command: npm run build
 
 workflows:
   run-pipeline:
     jobs:
-      - code-checks
-      - build:
-          requires:
-            - code-checks
-          filters:
-            branches:
-              ignore:
-                - master
+      - build
 
       # Build and push image to ECR
       - aws-ecr/build-and-push-image:
           requires:
-            - code-checks
+            - build
           executor: custom
           repo: taskforce-connector
           region: eu-north-1
@@ -84,7 +46,7 @@ workflows:
               only:
                 - master
 
-      # Pre API update (no hold required)
+      # Pre API update
       - aws-ecs/deploy-service-update:
           cluster: "step-shared-cluster"
           family: "pre-api-taskforce-connector"
@@ -101,7 +63,7 @@ workflows:
               only:
                 - master
 
-      # Pre indexer update (no hold required)
+      # Pre indexer update
       - aws-ecs/deploy-service-update:
           cluster: "step-shared-cluster"
           family: "pre-indexer-taskforce-connector"
@@ -111,16 +73,6 @@ workflows:
           enable-circuit-breaker: true
           force-new-deployment: true
           context: aws-account
-          requires:
-            - aws-ecr/build-and-push-image
-          filters:
-            branches:
-              only:
-                - master
-
-      # Live API and live indexer hold
-      - hold-live:
-          type: approval
           requires:
             - aws-ecr/build-and-push-image
           filters:
@@ -140,7 +92,6 @@ workflows:
           context: aws-account
           requires:
             - aws-ecr/build-and-push-image
-            - hold-live
           filters:
             branches:
               only:
@@ -158,7 +109,6 @@ workflows:
           context: aws-account
           requires:
             - aws-ecr/build-and-push-image
-            - hold-live
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - restore_cache:
           name: "Restore Package Cache"
           keys:
-            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: "Run build"
           command: |
@@ -32,18 +32,18 @@ jobs:
     steps:
         - checkout
         - run:
-            name: "Install pnpm"
-            command: sudo npm install -g pnpm@^9
+            name: "Install yarn"
+            command: sudo npm install -g yarn
         - restore_cache:
             name: "Restore Package Cache"
             keys:
-                - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+                - yarn-packages-{{ checksum "yarn.lock" }}
         - run:
             name: "Install dependencies"
-            command: pnpm install --frozen-lockfile
+            command: yarn --frozen-lockfile
         - save_cache:
             name: "Save Package Cache"
-            key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+            key: yarn-packages-{{ checksum "yarn.lock" }}
             paths:
                 - node_modules
 # no lint and type checks in this project
@@ -53,9 +53,9 @@ jobs:
 #        - run:
 #            name: "Run type checks"
 #            command: pnpm type-check
-        - run:
-            name: "Run tests"
-            command: pnpm test
+#        - run:
+#            name: "Run tests"
+#            command: pnpm test
 
 workflows:
   run-pipeline:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,161 @@ orbs:
   aws-ecr: circleci/aws-ecr@8.1.3
   aws-ecs: circleci/aws-ecs@3.2.0
 
+executors:
+  custom:
+    machine:
+      image: ubuntu-2404:2024.05.1
+    resource_class: xlarge
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:20.9.0
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+          name: "Restore Package Cache"
+          keys:
+            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+      - run:
+          name: "Run build"
+          command: |
+            npm run build
+  code-checks:
+    docker:
+      - image: cimg/node:20.9.0
+    steps:
+        - checkout
+        - run:
+            name: "Install pnpm"
+            command: sudo npm install -g pnpm@^9
+        - restore_cache:
+            name: "Restore Package Cache"
+            keys:
+                - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+        - run:
+            name: "Install dependencies"
+            command: pnpm install --frozen-lockfile
+        - save_cache:
+            name: "Save Package Cache"
+            key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+            paths:
+                - node_modules
+# no lint and type checks in this project
+#        - run:
+#            name: "Run lint checks"
+#            command: pnpm lint-check
+#        - run:
+#            name: "Run type checks"
+#            command: pnpm type-check
+        - run:
+            name: "Run tests"
+            command: pnpm test
+
 workflows:
-  standard-workflow:
+  run-pipeline:
     jobs:
+      - code-checks
+      - build:
+          requires:
+            - code-checks
+          filters:
+            branches:
+              ignore:
+                - master
+
+      # Build and push image to ECR
       - aws-ecr/build-and-push-image:
+          requires:
+            - code-checks
+          executor: custom
           repo: taskforce-connector
           region: eu-north-1
-          tag: "latest"
+          tag: ${CIRCLE_BRANCH},${CIRCLE_BRANCH}-<< pipeline.number >>,${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
           context: aws-account
+          extra-build-args: '--build-arg=NPM_TOKEN=${NPM_TOKEN}'
+          filters:
+            branches:
+              only:
+                - master
+
+      # Pre API update (no hold required)
+      - aws-ecs/deploy-service-update:
+          cluster: "step-shared-cluster"
+          family: "pre-api-taskforce-connector"
+          service-name: "pre-api-taskforce-connector-service"
+          container-env-var-updates: container=pre-api-taskforce-container,name=STEP_VERSION,value=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          container-image-name-updates: container=pre-api-taskforce-container,tag=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          enable-circuit-breaker: true
+          force-new-deployment: true
+          context: aws-account
+          requires:
+            - aws-ecr/build-and-push-image
+          filters:
+            branches:
+              only:
+                - master
+
+      # Pre indexer update (no hold required)
+      - aws-ecs/deploy-service-update:
+          cluster: "step-shared-cluster"
+          family: "pre-indexer-taskforce-connector"
+          service-name: "pre-indexer-taskforce-connector-service"
+          container-env-var-updates: container=pre-indexer-taskforce-container,name=STEP_VERSION,value=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          container-image-name-updates: container=pre-indexer-taskforce-container,tag=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          enable-circuit-breaker: true
+          force-new-deployment: true
+          context: aws-account
+          requires:
+            - aws-ecr/build-and-push-image
+          filters:
+            branches:
+              only:
+                - master
+
+      # Live API and live indexer hold
+      - hold-live:
+          type: approval
+          requires:
+            - aws-ecr/build-and-push-image
+          filters:
+            branches:
+              only:
+                - master
+
+      # Live API update
+      - aws-ecs/deploy-service-update:
+          cluster: "step-shared-cluster"
+          family: "live-api-taskforce-connector"
+          service-name: "live-api-taskforce-connector-service"
+          container-env-var-updates: container=live-api-taskforce-container,name=STEP_VERSION,value=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          container-image-name-updates: container=live-api-taskforce-container,tag=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          enable-circuit-breaker: true
+          force-new-deployment: true
+          context: aws-account
+          requires:
+            - aws-ecr/build-and-push-image
+            - hold-live
+          filters:
+            branches:
+              only:
+                - master
+
+      # Live indexer update
+      - aws-ecs/deploy-service-update:
+          cluster: "step-shared-cluster"
+          family: "live-indexer-taskforce-connector"
+          service-name: "live-indexer-taskforce-connector-service"
+          container-env-var-updates: container=live-indexer-taskforce-container,name=STEP_VERSION,value=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          container-image-name-updates: container=live-indexer-taskforce-container,tag=${CIRCLE_BRANCH}-<< pipeline.number >>-${CIRCLE_SHA1}
+          enable-circuit-breaker: true
+          force-new-deployment: true
+          context: aws-account
+          requires:
+            - aws-ecr/build-and-push-image
+            - hold-live
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,14 @@ jobs:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
+          name: "Install dependencies"
+          command: yarn --frozen-lockfile
+      - save_cache:
+          name: "Save Package Cache"
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+      - run:
           name: "Run build"
           command: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,7 @@ typings/
 # dotenv environment variables file
 .env
 
+# webstorm-specific files
+.idea
+
 dist/*


### PR DESCRIPTION
ticket: https://step-finance.atlassian.net/browse/SF-5622

I've made changes to be same as we have in fetchers repo and made adjustments to match the actual taskforce deployment.
- Both live and pre deployments are going to `step-shared-cluster` as opposed to other deployments
- 4 deployments are triggered on master, but live ones are behind single approve hold
- I've commented out some stuff that other repos have (like type checks and tests) but left it inside so its easy to use this code as reference for other repos if needed

Note for reviewers - The thing I'm not 100% sure is if "family" is correct, I assume those are task definitions so I took the one I found in task definitions JSON.